### PR TITLE
Fireworks: Live Volume Steps [2/2]

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1295,4 +1295,14 @@
         <item>3</item>
         <item>4</item>
     </string-array>
+
+    <!-- Volume step options. -->
+    <string-array name="volume_steps_entries" translatable="false">
+        <item>@string/volume_steps_60</item>
+        <item>@string/volume_steps_45</item>
+        <item>@string/volume_steps_30</item>
+        <item>@string/volume_steps_15</item>
+        <item>@string/volume_steps_7</item>
+        <item>@string/volume_steps_5</item>
+    </string-array>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1249,4 +1249,22 @@
     <!-- Fingerprint Ripple Effect -->
     <string name="enable_fingerprint_ripple_effect_title">Ripple effect</string>
     <string name="enable_fingerprint_ripple_effect_summary">Show ripple effect on unlock with fingerprint</string>
+
+    <!-- Live volume steps -->
+    <string name="volume_steps_title">Volume steps</string>
+    <string name="volume_steps_summary">Customize no. of steps in volume panel</string>
+    <string name="volume_steps_alarm_title">Volume steps: Alarm</string>
+    <string name="volume_steps_dtmf_title">Volume steps: DTMF</string>
+    <string name="volume_steps_music_title">Volume steps: Music</string>
+    <string name="volume_steps_notification_title">Volume steps: Notification</string>
+    <string name="volume_steps_ring_title">Volume steps: Ringer</string>
+    <string name="volume_steps_system_title">Volume steps: System</string>
+    <string name="volume_steps_voice_call_title">Volume steps: Voice Call</string>
+    <string name="volume_steps_reset">Reset</string>
+    <string name="volume_steps_60">60</string>
+    <string name="volume_steps_45">45</string>
+    <string name="volume_steps_30">30</string>
+    <string name="volume_steps_15">15</string>
+    <string name="volume_steps_7">7</string>
+    <string name="volume_steps_5">5</string>
 </resources>

--- a/res/xml/spark_settings_buttons.xml
+++ b/res/xml/spark_settings_buttons.xml
@@ -312,5 +312,11 @@
             android:key="swap_volume_buttons"
             android:title="@string/swap_volume_buttons_title"
             android:summary="@string/swap_volume_buttons_summary" />
+
+        <Preference
+            android:key="volume_steps"
+            android:title="@string/volume_steps_title"
+            android:summary="@string/volume_steps_summary"
+            android:fragment="com.spark.settings.fragments.VolumeSteps" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/res/xml/spark_settings_themes.xml
+++ b/res/xml/spark_settings_themes.xml
@@ -121,7 +121,7 @@
             android:title="@string/qs_header_image_title"
             android:defaultValue="0"
             settings:interval="1"
-            android:max="74"
+            android:max="64"
             android:min="0" />
 
     <com.spark.settings.preferences.SystemSettingListPreference

--- a/res/xml/volume_steps_settings.xml
+++ b/res/xml/volume_steps_settings.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+        android:title="@string/volume_steps_title"
+        xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
+
+        <ListPreference
+                android:key="volume_steps_alarm"
+                android:title="@string/volume_steps_alarm_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+        <ListPreference
+                android:key="volume_steps_dtmf"
+                android:title="@string/volume_steps_dtmf_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+        <ListPreference
+                android:key="volume_steps_music"
+                android:title="@string/volume_steps_music_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+        <ListPreference
+                android:key="volume_steps_notification"
+                android:title="@string/volume_steps_notification_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+        <ListPreference
+                android:key="volume_steps_ring"
+                android:title="@string/volume_steps_ring_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+        <ListPreference
+                android:key="volume_steps_system"
+                android:title="@string/volume_steps_system_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+        <ListPreference
+                android:key="volume_steps_voice_call"
+                android:title="@string/volume_steps_voice_call_title"
+                android:entries="@array/volume_steps_entries"
+                android:entryValues="@array/volume_steps_entries" />
+
+</PreferenceScreen>

--- a/src/com/spark/settings/fragments/VolumeSteps.java
+++ b/src/com/spark/settings/fragments/VolumeSteps.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2018-2021 crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spark.settings.fragments;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.media.AudioManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.telephony.TelephonyManager;
+import android.text.TextUtils;
+import android.util.Log;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.logging.nano.MetricsProto;
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class VolumeSteps extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener {
+
+    private static final String TAG = "VolumeSteps";
+    private static final String VOLUME_STEP_DEFAULTS = "volume_step_defaults";
+    private static final String FIRST_RUN_KEY = "first_run";
+
+    // base map of all preference keys and the associated stream
+    private static final Map<String, Integer> volume_map = new HashMap<String, Integer>();
+    static {
+        volume_map.put("volume_steps_alarm", new Integer(AudioManager.STREAM_ALARM));
+        volume_map.put("volume_steps_dtmf", new Integer(AudioManager.STREAM_DTMF));
+        volume_map.put("volume_steps_music", new Integer(AudioManager.STREAM_MUSIC));
+        volume_map.put("volume_steps_notification", new Integer(AudioManager.STREAM_NOTIFICATION));
+        volume_map.put("volume_steps_ring", new Integer(AudioManager.STREAM_RING));
+        volume_map.put("volume_steps_system", new Integer(AudioManager.STREAM_SYSTEM));
+        volume_map.put("volume_steps_voice_call", new Integer(AudioManager.STREAM_VOICE_CALL));
+    }
+
+    // entries to remove on non-telephony devices
+    private static final Set<String> telephony_set = new HashSet<String>();
+    static {
+        telephony_set.add("volume_steps_dtmf");
+        telephony_set.add("volume_steps_ring");
+        telephony_set.add("volume_steps_voice_call");
+    }
+
+    // set of available pref keys after device configuration filter
+    private Set<String> mAvailableKeys = new HashSet<String>();
+    private AudioManager mAudioManager;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.volume_steps_settings);
+        mAudioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+
+        final PreferenceScreen prefScreen = getPreferenceScreen();
+        mAvailableKeys = volume_map.keySet();
+
+        // remove invalid audio stream prefs
+        boolean isPhone = TelephonyManager.getDefault().getCurrentPhoneType() != TelephonyManager.PHONE_TYPE_NONE;
+
+        if (!isPhone) {
+            // remove telephony keys from available set
+            mAvailableKeys.removeAll(telephony_set);
+            for (String key : telephony_set) {
+                Preference toRemove = prefScreen.findPreference(key);
+                if (toRemove != null) {
+                    prefScreen.removePreference(toRemove);
+                }
+            }
+        }
+
+        // check prefs for initial run of this fragment
+        final boolean firstRun = checkForFirstRun();
+
+        // entries array isn't translatable ugh
+        final String defEntry = getString(R.string.volume_steps_reset);
+
+        // initialize prefs: set defaults if first run, set listeners and update values
+        for (String key : mAvailableKeys) {
+            Preference pref = prefScreen.findPreference(key);
+            if (pref == null || !(pref instanceof ListPreference)) {
+                continue;
+            }
+            final ListPreference listPref = (ListPreference) pref;
+            int steps = mAudioManager.getStreamMaxVolume(volume_map.get(key));
+            if (firstRun) {
+                saveDefaultSteps(listPref, steps);
+            }
+            final int defSteps = getDefaultSteps(listPref);
+            CharSequence[] entries = new CharSequence[listPref.getEntries().length + 1];
+            CharSequence[] values = new CharSequence[listPref.getEntryValues().length + 1];
+
+            for (int i = 0; i < entries.length; i++) {
+                if (i == 0) {
+                    entries[i] = defEntry;
+                    values[i] = String.valueOf(defSteps);
+                    continue;
+                }
+                entries[i] = listPref.getEntries()[i - 1];
+                values[i] = listPref.getEntryValues()[i - 1];
+            }
+            listPref.setEntries(entries);
+            listPref.setEntryValues(values);
+            updateVolumeStepPrefs(listPref, steps);
+            listPref.setOnPreferenceChangeListener(this);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        if (preference.hasKey() && mAvailableKeys.contains(preference.getKey())) {
+            commitVolumeSteps(preference, Integer.parseInt(objValue.toString()));
+        }
+        return true;
+    }
+
+    private SharedPreferences getDefaultStepsPrefs() {
+        return getActivity().getSharedPreferences(VOLUME_STEP_DEFAULTS,
+                Context.MODE_PRIVATE);
+    }
+
+    // test for initial run of this fragment
+    private boolean checkForFirstRun() {
+        String isFirstRun = getDefaultStepsPrefs().getString(FIRST_RUN_KEY, null);
+        if (isFirstRun == null) {
+            getDefaultStepsPrefs().edit().putString(FIRST_RUN_KEY, "first_run_initialized").commit();
+            return true;
+        }
+        return false;
+    }
+
+    private int getDefaultSteps(Preference pref) {
+        if (pref == null || !(pref instanceof ListPreference)) {
+            // unlikely
+            return -1;
+        }
+        String key = pref.getKey();
+        String value = getDefaultStepsPrefs().getString(key, null);
+        if (value == null) {
+            // unlikely
+            return -1;
+        }
+        return Integer.parseInt(value);
+    }
+
+    // on the initial run, let's store true device defaults in sharedPrefs
+    private void saveDefaultSteps(Preference volPref, int defaultSteps) {
+        String key = volPref.getKey();
+        getDefaultStepsPrefs().edit().putString(key, String.valueOf(defaultSteps)).commit();
+    }
+
+    private void updateVolumeStepPrefs(Preference pref, int steps) {
+        if (pref == null || !(pref instanceof ListPreference)) {
+            return;
+        }
+        final ListPreference listPref = (ListPreference) pref;
+        listPref.setSummary(String.valueOf(steps));
+        listPref.setValue(String.valueOf(steps));
+    }
+
+    private void commitVolumeSteps(Preference pref, int steps) {
+        Settings.System.putInt(getContentResolver(), pref.getKey(), steps);
+        mAudioManager.setStreamMaxVolume(volume_map.get(pref.getKey()), steps);
+        updateVolumeStepPrefs(pref, steps);
+        Log.i(TAG, "Volume steps:" + pref.getKey() + "" + String.valueOf(steps));
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.SPARK_SETTINGS;
+    }
+}


### PR DESCRIPTION
-Volume steps changes are instant, no need to reboot!

LiveVolumeSteps: transitioned volume steps volume normalization.

-This calculates an equivalent volume ratio for the new volume steps.
-example: Volume steps are set at 60. Volume is set at 5. That is very low volume. Then volume steps are switched to 5. Now you are instantly in a state were your volume steps are 5 and your volume is 5. That's full volume! This fixes that issue. -So it basically keeps the volume from jumping around while your changing volume steps. It may be a little lower but should be very close.

Change-Id: I264fc1a364eb62862710451c370102d110c095a7